### PR TITLE
ci: migrate runners from lux-build to hanzo-build/hanzo-deploy (ARC consolidation)

### DIFF
--- a/.github/workflows/build-lux.yml
+++ b/.github/workflows/build-lux.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build:
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-build-linux-amd64
     permissions:
       contents: read
       packages: write
@@ -74,7 +74,7 @@ jobs:
   deploy:
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-deploy-linux-amd64
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- Migrate `build-lux.yml`:
  - build job: `lux-build-linux-amd64` → `hanzo-build-linux-amd64`
  - deploy job: `lux-build-linux-amd64` → `hanzo-deploy-linux-amd64` (correct runner class for kubectl work)
- Part of ARC fleet consolidation: one canonical self-hosted runner pool for hanzo/lux/zoo/liquidity.

## Why
Duplicate scale sets (lux-build-* and hanzo-build-*) violate "one way to do everything". The hanzo ARC is the canonical fleet per hanzo/CLAUDE.md:
- hanzo-build-linux-amd64 (DO ARC, max 30) for builds
- hanzo-build-linux-arm64 (GKE T2A Ampere ARC, max 30) for ARM builds
- hanzo-deploy-linux-amd64 (DO ARC, max 20) for kubectl deploys

After this and the matching lux/universe PR lands, the lux-build-linux-amd64 scale set spins down to 0 replicas.

## Test plan
- [ ] Push to branch schedules build job on hanzo-build-linux-amd64
- [ ] Merge to main schedules deploy job on hanzo-deploy-linux-amd64
- [ ] Image builds and pushes to ghcr.io/luxfi/explore
- [ ] K8s rollout completes across all target namespaces